### PR TITLE
fix bug: studentview with localStorage

### DIFF
--- a/client/app/screen/StudentViewScreen.js
+++ b/client/app/screen/StudentViewScreen.js
@@ -63,9 +63,16 @@ export default function StudentViewScreen() {
       // use this format to load localStorage value.
       setSubmission((prev) => {
         const values = JSON.parse(localStorage.getItem("answer"));
+        // only get values in localStorage which is the current question's response
+        const currentQuestion = {};
+        for (const key of Object.keys(values)) {
+          if (questions.find((el) => el.id === Number(key))) {
+            currentQuestion[key] = values[key];
+          }
+        }
         return {
           ...prev,
-          ...values,
+          ...currentQuestion,
         };
       });
     }


### PR DESCRIPTION
the bug: the localStorage would have some question and response which is not belongs to current assessment,
so when student submit it, there will have problem in grading table. 
only send request with the question and response belongs to the assessment. 